### PR TITLE
Fix imports so that browser does not complain

### DIFF
--- a/imperial.js
+++ b/imperial.js
@@ -1,6 +1,6 @@
 import { Nation } from "./constants.js";
 import Action from "./action.js";
-import setup from "./setup";
+import setup from "./setup.js";
 
 export default class Imperial {
   static fromLog(log) {

--- a/setup.js
+++ b/setup.js
@@ -1,4 +1,4 @@
-import { Nation } from "./constants";
+import { Nation } from "./constants.js";
 
 const error = (want) => (x) => {
   throw new Error(`got=${x.value}, want=${want}`);


### PR DESCRIPTION
Without the .js suffix I was getting errors about loading the modules
and that their file type ("text/plain", I think?) was wrong.