### PR TITLE
Improve the visibility of valid options in the game

### DIFF
--- a/app/javascript/src/assets/tailwind.css
+++ b/app/javascript/src/assets/tailwind.css
@@ -26,6 +26,11 @@ button {
   font-size: 1.2rem;
 }
 
+.hoverable {
+  stroke-width: 2px;
+  filter: brightness(0.7);
+}
+
 .hoverable:hover {
   filter: url(#brightness);
 }


### PR DESCRIPTION
Current solution for issue #134 is to have an _hoverable_ class that looks different from the default style and also the _hoverable:hover_ config.
This will highlight not only the valid provinces to choose for an action but also the destination provinces for armies and the valid slots in the rondel.