### PR TITLE
Implements unit limits for import and production

### DIFF
--- a/app/javascript/lib/imperial.js
+++ b/app/javascript/lib/imperial.js
@@ -1040,11 +1040,11 @@ export default class Imperial {
             const units = this.units.get(nation).get(province);
             if (this.nobodyIsOccupying(province, nation)) {
               if (this.provinces.get(province).factory === "shipyard" &&
-                  !this.overUnitLimit(action.payload.nation, "fleets", 1)
+                  !this.overUnitLimit(action.payload.nation, "fleet", 1)
               ) {
                 units.fleets++;
-              } else if (this.provinces.get(province).factory != "shipyard" &&
-                        !this.overUnitLimit(action.payload.nation, "armies", 1)
+              } else if (this.provinces.get(province).factory !== "shipyard" &&
+                        !this.overUnitLimit(action.payload.nation, "army", 1)
               ) {
                 units.armies++;
               }
@@ -1219,7 +1219,7 @@ export default class Imperial {
     const unoccupiedHomeProvinces = [...homeProvinces].filter(province => {
       let unoccupied = true;
       for (const [nation] of this.nations) {
-        if (nation != action.payload.nation && this.units.get(nation).get(province).armies > 0) {
+        if (nation !== action.payload.nation && this.units.get(nation).get(province).armies > 0) {
           unoccupied = false
         }
       }
@@ -1232,31 +1232,27 @@ export default class Imperial {
       this.maxImports = 3;
     }
 
-    if (this.armyCount(action.payload.nation) == this.unitLimits.get(action.payload.nation).armies) {
-      this.availableActions = availableActions;
-      this.importing = true;
-      return;
-    }
+    // if (this.armyCount(action.payload.nation) == this.unitLimits.get(action.payload.nation).armies) {
+    //   this.availableActions = availableActions;
+    //   this.importing = true;
+    //   return;
+    // }
 
-    if (this.fleetCount(action.payload.nation) == this.unitLimits.get(action.payload.nation).fleets) {
-      this.availableActions = availableActions;
-      this.importing = true;
-      return;
-    }
-
-    // const imports = Array.from({length: this.maxImports}, (_, i) => i + 1);
-    // this.unitLimits.get(action.payload.nation)[unitType]);
-    // overUnitLimit(nation, unitType, numberOfPlacements)
+    // if (this.fleetCount(action.payload.nation) == this.unitLimits.get(action.payload.nation).fleets) {
+    //   this.availableActions = availableActions;
+    //   this.importing = true;
+    //   return;
+    // }
 
     for (const province of unoccupiedHomeProvinces) {
       if (treasury >= 1) {
-        if (!this.overUnitLimit(action.payload.nation, "armies", 1)) {
+        if (!this.overUnitLimit(action.payload.nation, "army", 1)) {
           availableActions.add(
             Action.import({ placements: [{ province, type: "army" }] })
           );
         };
         if (this.board.graph.get(province).factoryType === "shipyard" &&
-            !this.overUnitLimit(action.payload.nation, "fleets", 1)
+            !this.overUnitLimit(action.payload.nation, "fleet", 1)
         ) {
           availableActions.add(
             Action.import({ placements: [{ province, type: "fleet" }] })
@@ -1266,7 +1262,7 @@ export default class Imperial {
 
       for (const province2 of unoccupiedHomeProvinces) {
         if (treasury >= 2) {
-          if (!this.overUnitLimit(action.payload.nation, "armies", 2)) {
+          if (!this.overUnitLimit(action.payload.nation, "army", 2)) {
           availableActions.add(
             Action.import({
               placements: [
@@ -1276,8 +1272,8 @@ export default class Imperial {
             })
           )};
           if (this.board.graph.get(province).factoryType === "shipyard" && 
-              !this.overUnitLimit(action.payload.nation, "fleets", 1) &&
-              !this.overUnitLimit(action.payload.nation, "armies", 1)
+              !this.overUnitLimit(action.payload.nation, "fleet", 1) &&
+              !this.overUnitLimit(action.payload.nation, "army", 1)
           ) {
             availableActions.add(
               Action.import({
@@ -1289,8 +1285,8 @@ export default class Imperial {
             );
           }
           if (this.board.graph.get(province2).factoryType === "shipyard" &&
-              !this.overUnitLimit(action.payload.nation, "fleets", 1) &&
-              !this.overUnitLimit(action.payload.nation, "armies", 1)
+              !this.overUnitLimit(action.payload.nation, "fleet", 1) &&
+              !this.overUnitLimit(action.payload.nation, "army", 1)
           ) {
             availableActions.add(
               Action.import({
@@ -1304,7 +1300,7 @@ export default class Imperial {
           if (
             this.board.graph.get(province).factoryType === "shipyard" &&
             this.board.graph.get(province2).factoryType === "shipyard" &&
-            !this.overUnitLimit(action.payload.nation, "fleets", 2)
+            !this.overUnitLimit(action.payload.nation, "fleet", 2)
           ) {
             availableActions.add(
               Action.import(
@@ -1317,7 +1313,7 @@ export default class Imperial {
 
         for (const province3 of unoccupiedHomeProvinces) {
           if (treasury >= 3) {
-            if (!this.overUnitLimit(action.payload.nation, "armies", 3)) {
+            if (!this.overUnitLimit(action.payload.nation, "army", 3)) {
             availableActions.add(
               Action.import({
                 placements: [
@@ -1328,8 +1324,8 @@ export default class Imperial {
               })
             )};
             if (this.board.graph.get(province).factoryType === "shipyard" &&
-                !this.overUnitLimit(action.payload.nation, "fleets", 1) &&
-                !this.overUnitLimit(action.payload.nation, "armies", 2)
+                !this.overUnitLimit(action.payload.nation, "fleet", 1) &&
+                !this.overUnitLimit(action.payload.nation, "army", 2)
             ) {
               availableActions.add(
                 Action.import({
@@ -1342,8 +1338,8 @@ export default class Imperial {
               );
             }
             if (this.board.graph.get(province2).factoryType === "shipyard" &&
-                !this.overUnitLimit(action.payload.nation, "fleets", 1) &&
-                !this.overUnitLimit(action.payload.nation, "armies", 2)
+                !this.overUnitLimit(action.payload.nation, "fleet", 1) &&
+                !this.overUnitLimit(action.payload.nation, "army", 2)
             ) {
               availableActions.add(
                 Action.import({
@@ -1356,8 +1352,8 @@ export default class Imperial {
               );
             }
             if (this.board.graph.get(province3).factoryType === "shipyard" &&
-                !this.overUnitLimit(action.payload.nation, "fleets", 1) &&
-                !this.overUnitLimit(action.payload.nation, "armies", 2)
+                !this.overUnitLimit(action.payload.nation, "fleet", 1) &&
+                !this.overUnitLimit(action.payload.nation, "army", 2)
             ) {
               availableActions.add(
                 Action.import({
@@ -1372,8 +1368,8 @@ export default class Imperial {
             if (
               this.board.graph.get(province).factoryType === "shipyard" &&
               this.board.graph.get(province2).factoryType === "shipyard" &&
-              !this.overUnitLimit(action.payload.nation, "fleets", 2) &&
-              !this.overUnitLimit(action.payload.nation, "armies", 1)
+              !this.overUnitLimit(action.payload.nation, "fleet", 2) &&
+              !this.overUnitLimit(action.payload.nation, "army", 1)
             ) {
               availableActions.add(
                 Action.import({
@@ -1388,8 +1384,8 @@ export default class Imperial {
             if (
               this.board.graph.get(province).factoryType === "shipyard" &&
               this.board.graph.get(province3).factoryType === "shipyard" &&
-              !this.overUnitLimit(action.payload.nation, "fleets", 2) &&
-              !this.overUnitLimit(action.payload.nation, "armies", 1)
+              !this.overUnitLimit(action.payload.nation, "fleet", 2) &&
+              !this.overUnitLimit(action.payload.nation, "army", 1)
             ) {
               availableActions.add(
                 Action.import({
@@ -1404,8 +1400,8 @@ export default class Imperial {
             if (
               this.board.graph.get(province2).factoryType === "shipyard" &&
               this.board.graph.get(province3).factoryType === "shipyard" &&
-              !this.overUnitLimit(action.payload.nation, "fleets", 2) &&
-              !this.overUnitLimit(action.payload.nation, "armies", 1)
+              !this.overUnitLimit(action.payload.nation, "fleet", 2) &&
+              !this.overUnitLimit(action.payload.nation, "army", 1)
             ) {
               availableActions.add(
                 Action.import({
@@ -1421,7 +1417,7 @@ export default class Imperial {
               this.board.graph.get(province).factoryType === "shipyard" &&
               this.board.graph.get(province2).factoryType === "shipyard" &&
               this.board.graph.get(province3).factoryType === "shipyard" &&
-              !this.overUnitLimit(action.payload.nation, "fleets", 3)
+              !this.overUnitLimit(action.payload.nation, "fleet", 3)
             ) {
               availableActions.add(
                 Action.import({
@@ -1627,10 +1623,10 @@ export default class Imperial {
   }
 
   overUnitLimit(nation, unitType, numberOfPlacements) {
-    if (unitType === "armies") {
-      return this.armyCount(nation) + numberOfPlacements > this.unitLimits.get(nation)[unitType];
+    if (unitType === "army") {
+      return this.armyCount(nation) + numberOfPlacements > this.unitLimits.get(nation).armies;
     } else {
-      return this.fleetCount(nation) + numberOfPlacements > this.unitLimits.get(nation)[unitType];
+      return this.fleetCount(nation) + numberOfPlacements > this.unitLimits.get(nation).fleets;
     }
   }
 

--- a/app/javascript/lib/imperial.js
+++ b/app/javascript/lib/imperial.js
@@ -1232,18 +1232,6 @@ export default class Imperial {
       this.maxImports = 3;
     }
 
-    // if (this.armyCount(action.payload.nation) == this.unitLimits.get(action.payload.nation).armies) {
-    //   this.availableActions = availableActions;
-    //   this.importing = true;
-    //   return;
-    // }
-
-    // if (this.fleetCount(action.payload.nation) == this.unitLimits.get(action.payload.nation).fleets) {
-    //   this.availableActions = availableActions;
-    //   this.importing = true;
-    //   return;
-    // }
-
     for (const province of unoccupiedHomeProvinces) {
       if (treasury >= 1) {
         if (!this.overUnitLimit(action.payload.nation, "army", 1)) {

--- a/app/javascript/lib/imperial.test.js
+++ b/app/javascript/lib/imperial.test.js
@@ -616,6 +616,122 @@ describe("imperial", () => {
           expect(game.importing).toEqual(true);
         });
 
+        test("importing when armies are at the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").armies = game.unitLimits.get(Nation.AH).armies;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+        test("importing when armies are 1 below the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").armies = game.unitLimits.get(Nation.AH).armies - 1;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }] })
+          );
+
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+        test("importing when armies are 2 below the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").armies = game.unitLimits.get(Nation.AH).armies - 2;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }] })
+          );
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }, { province: "a", type: "army" }] })
+          );
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+        test("importing when armies are 3 below the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").armies = game.unitLimits.get(Nation.AH).armies - 3;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }] })
+          );
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }, { province: "a", type: "army" }] })
+          );
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }, { province: "a", type: "army" }, { province: "a", type: "army" }] })
+          );
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+
         test("nation can import fleets in their coastal province", () => {
           const board = new GameBoard({
             nodes: [
@@ -737,6 +853,454 @@ describe("imperial", () => {
                 { province: "a", type: "fleet" },
                 { province: "a", type: "army" },
                 { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+
+        test("importing when fleets are at the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH, factoryType: "shipyard" },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").fleets = game.unitLimits.get(Nation.AH).fleets;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+        test("importing when fleets are 1 below the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH, factoryType: "shipyard" },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").fleets = game.unitLimits.get(Nation.AH).fleets - 1;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }] })
+          );
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "fleet" }] })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+        test("importing when fleets are 2 below the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH, factoryType: "shipyard" },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").fleets = game.unitLimits.get(Nation.AH).fleets - 2;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }] })
+          );
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "fleet" }] })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+        test("importing when fleets are 3 below the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH, factoryType: "shipyard" },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").fleets = game.unitLimits.get(Nation.AH).fleets - 3;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }] })
+          );
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "fleet" }] })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "fleet" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+        test("importing when armies and fleets are both at the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH, factoryType: "shipyard" },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").armies = game.unitLimits.get(Nation.AH).armies;
+          game.units.get(Nation.AH).get("a").fleets = game.unitLimits.get(Nation.AH).fleets;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          game.tick(
+            Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
+          );
+
+          expect(game.availableActions).toEqual(availableActions);
+          expect(game.nations.get(Nation.AH).rondelPosition).toEqual("import");
+          expect(game.importing).toEqual(true);
+        });
+
+        test("importing when armies and fleets are both 1 under the limit", () => {
+          const board = new GameBoard({
+            nodes: [
+              { name: "a", nation: Nation.AH, factoryType: "shipyard" },
+              { name: "b", nation: null },
+              { name: "c", nation: Nation.IT }
+            ],
+            edges: []
+          });
+
+          const game = new Imperial(board);
+          initialize(game);
+          game.units.get(Nation.AH).get("a").armies = game.unitLimits.get(Nation.AH).armies - 1;
+          game.units.get(Nation.AH).get("a").fleets = game.unitLimits.get(Nation.AH).fleets - 1;
+          const availableActions = new Set([Action.import({ placements: [] })]);
+
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }] })
+          );
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "fleet" }] })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "fleet" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "fleet" },
+                { province: "a", type: "army" }
               ]
             })
           );
@@ -903,7 +1467,7 @@ describe("imperial", () => {
         });
       });
 
-      describe("production1 or production2", () => {
+      describe.only("production1 or production2", () => {
         const newGame = () => {
           const board = new GameBoard({
             nodes: [{ name: "a", nation: Nation.AH }],
@@ -938,7 +1502,7 @@ describe("imperial", () => {
               expect(game.units.get(Nation.AH).get("a").armies).toEqual(0);
             });
 
-            test("a unit is not produce in a province that has an occupied factory", () => {
+            test("a unit is not produced in a province that has an occupied factory", () => {
               const game = newGame();
               game.provinces.get("a").factory = "armaments";
               game.units.get(Nation.IT).get("a").armies = 1;
@@ -948,6 +1512,31 @@ describe("imperial", () => {
               );
 
               expect(game.units.get(Nation.AH).get("a").armies).toEqual(0);
+            });
+
+            test("no more armies are produced when that unit limit is reached", () => {
+              const game = newGame();
+              game.provinces.get("a").factory = "armaments";
+              game.units.get(Nation.AH).get("a").armies = game.unitLimits.get(Nation.AH).armies;
+              
+              game.tick(
+                Action.rondel({ slot: production, cost: 0, nation: Nation.AH })
+              );
+
+              expect(game.units.get(Nation.AH).get("a").fleets).toEqual(0);
+              expect(game.units.get(Nation.AH).get("a").armies).toEqual(game.unitLimits.get(Nation.AH).armies);
+            });
+
+            test("no more fleets are produced when that unit limit is reached", () => {
+              const game = newGame();
+              game.provinces.get("a").factory = "shipyard";
+              game.units.get(Nation.AH).get("a").fleets = game.unitLimits.get(Nation.AH).fleets;
+
+              game.tick(
+                Action.rondel({ slot: production, cost: 0, nation: Nation.AH })
+              );
+              expect(game.units.get(Nation.AH).get("a").armies).toEqual(0);
+              expect(game.units.get(Nation.AH).get("a").fleets).toEqual(game.unitLimits.get(Nation.AH).fleets);
             });
           });
 

--- a/app/javascript/lib/imperial.test.js
+++ b/app/javascript/lib/imperial.test.js
@@ -881,6 +881,27 @@ describe("imperial", () => {
           game.units.get(Nation.AH).get("a").fleets = game.unitLimits.get(Nation.AH).fleets;
           const availableActions = new Set([Action.import({ placements: [] })]);
 
+          availableActions.add(
+            Action.import({ placements: [{ province: "a", type: "army" }] })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+          availableActions.add(
+            Action.import({
+              placements: [
+                { province: "a", type: "army" },
+                { province: "a", type: "army" },
+                { province: "a", type: "army" }
+              ]
+            })
+          );
+
           game.tick(
             Action.rondel({ slot: "import", cost: 0, nation: Nation.AH })
           );
@@ -1467,7 +1488,7 @@ describe("imperial", () => {
         });
       });
 
-      describe.only("production1 or production2", () => {
+      describe("production1 or production2", () => {
         const newGame = () => {
           const board = new GameBoard({
             nodes: [{ name: "a", nation: Nation.AH }],

--- a/app/javascript/lib/standardSetup.js
+++ b/app/javascript/lib/standardSetup.js
@@ -182,8 +182,21 @@ export default ({ players, provinceNames }) => {
     }
     provinces.set(province, { factory });
   }
+
+  const unitLimits = new Map();
+
+  for (const nation of Nation) {
+    if (nation == Nation.AH) {
+      unitLimits.set(nation, {armies: 10, fleets: 6});
+    } else if (nation == Nation.GB) {
+      unitLimits.set(nation, {armies: 6, fleets: 10});
+    } else {
+      unitLimits.set(nation, {armies: 8, fleets: 8});
+    };
+  };
+
   out.provinces = provinces;
   out.currentNation = Nation.AH;
-
+  out.unitLimits = unitLimits;
   return out;
 };

--- a/app/javascript/lib/standardSetup.js
+++ b/app/javascript/lib/standardSetup.js
@@ -186,9 +186,9 @@ export default ({ players, provinceNames }) => {
   const unitLimits = new Map();
 
   for (const nation of Nation) {
-    if (nation == Nation.AH) {
+    if (nation === Nation.AH) {
       unitLimits.set(nation, {armies: 10, fleets: 6});
-    } else if (nation == Nation.GB) {
+    } else if (nation === Nation.GB) {
       unitLimits.set(nation, {armies: 6, fleets: 10});
     } else {
       unitLimits.set(nation, {armies: 8, fleets: 8});


### PR DESCRIPTION
Fix for #384 
Adds unit limits for each nation in standardSetup.js
When importing, if the unit limit for that nation is crossed the action is reset.
When producing, if the unit limit for that nation is reached no more units of that type are produced.