### PR TITLE
Clarified description when 2 units are coexisting

### DIFF
--- a/app/javascript/src/components/GameLogEntry.vue
+++ b/app/javascript/src/components/GameLogEntry.vue
@@ -109,6 +109,20 @@ export default {
       }
       return '';
     },
+    unitTypeByDestination_Singular(destination) {
+      if (this.board.graph.get(destination).isOcean) {
+        return 'fleet';
+      } else {
+        return 'army';
+      }
+    },
+    unitTypeByDestination_Plural(destination) {
+      if (this.board.graph.get(destination).isOcean) {
+        return 'fleets';
+      } else {
+        return 'armies';
+      }
+    },
     processAction(action) {
       const notImplemented = 'NOT IMPLEMENTED';
       switch (action.type) {
@@ -221,20 +235,20 @@ export default {
       return `Imported a total of ${provincesList.length} ${unit} into ${provincesText}.`;
     },
     maneuverAction(payload) {
-      let unit;
-      if (this.board.graph.get(payload.destination).isOcean) {
-        unit = 'a fleet';
-      } else {
-        unit = 'an army';
-      }
+      const unit = this.unitTypeByDestination_Singular(payload.destination);
       const origin = this.capitalize(payload.origin);
       const destination = this.capitalize(payload.destination);
+
       return `Moved ${unit} from ${origin} to ${destination}.`;
     },
     coexistAction(payload) {
+      const units = this.capitalize(this.unitTypeByDestination_Plural(payload.province));
+      // technically it could be a fleet in port sharing the province with an army
+
       const province = this.capitalize(payload.province);
       const nations = `${stringify(payload.incumbent.value)} and ${stringify(payload.challenger.value)}`;
-      return `Armies from ${nations} are peacefully coexisting in ${province}.`;
+
+      return `${units} from ${nations} are peacefully coexisting in ${province}.`;
     },
     fightAction(payload) {
       const province = this.capitalize(payload.province);

--- a/app/javascript/src/components/GameLogEntry.vue
+++ b/app/javascript/src/components/GameLogEntry.vue
@@ -111,9 +111,9 @@ export default {
     },
     unitTypeByDestination_Singular(destination) {
       if (this.board.graph.get(destination).isOcean) {
-        return 'fleet';
+        return 'a fleet';
       } else {
-        return 'army';
+        return 'an army';
       }
     },
     unitTypeByDestination_Plural(destination) {


### PR DESCRIPTION
# Changes:
- Units coexisting are no longer always referred to as `Armies`

## Screenshots:
- Before:
![image](https://user-images.githubusercontent.com/28380984/225986140-3fa239fa-ccd3-404d-8921-f95d7dc0c96d.png)
- After (slightly outdated, reattached the `a/an` particle to single units) :
![After](https://user-images.githubusercontent.com/28380984/225986039-2f12178a-8ed5-4cdc-bf7d-292e295c20b9.png)

## Comments:
- Just something that's always bothered me 🤷 
