### PR TITLE
Import/Export games

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,7 @@
             "object": true
         }],
         "vue/multi-word-component-names": ["error", {
-            "ignores": ["Board", "Game", "Province", "Flag", "Bond", "Player", "Rondel", "About", "Header", "Home"]
+            "ignores": ["Board", "Game", "Province", "Flag", "Bond", "Player", "Rondel", "About", "Header", "Home", "Import"]
         }],
         "vue/no-reserved-component-names": ["off"],
         "vue/no-v-html": ["off"]

--- a/README.md
+++ b/README.md
@@ -82,3 +82,17 @@ To run Ruby RSpec tests, run the following command from the project root:
 ```
 rspec
 ```
+
+## Local debugging
+
+Production games will often present situations that are hard to reproduce locally and therefore get challening to debug. Therefore, we have implemented the ability to **export** and **import** games.
+
+### Exporting a game
+
+Visit `/exports/[game_id]` and a `JSON` file will be downloaded to your computer. This file contains the game log and can be used when importing a game.
+
+### Importing a game
+
+Visit `http://localhost:3000/import_game` and paste the contents of the downloaded `JSON` in the box and click `Import game`. This will reconstruct the game locally in your database and let you play around with it and, hopefully, improve debugging.
+
+Please *only* do this in local development. Imported games are not allowed on the production database.

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -1,0 +1,10 @@
+class ExportsController < ApplicationController
+  def show
+    log = Game.find(params[:id]).log.to_json
+    send_data(
+      log,
+      type: "application/json; header=present",
+      disposition: "attachment; filename=imperial-#{params[:id]}.json"
+    )
+  end
+end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,5 +1,9 @@
 class ImportsController < ApplicationController
   def create
+    # There should be no imported games on production.
+    # Importing is only for local debugging of production games.
+    return if Rails.env == "production"
+
     log = JSON.parse(params[:log])
     game = Game.import(log, params[:hostId])
 

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,7 +1,7 @@
 class ImportsController < ApplicationController
   def create
     log = JSON.parse(params[:log])
-    game = Game.import(log)
+    game = Game.import(log, params[:hostId])
 
     render json: game.to_json
   end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,0 +1,8 @@
+class ImportsController < ApplicationController
+  def create
+    log = JSON.parse(params[:log])
+    game = Game.import(log)
+
+    render json: game.to_json
+  end
+end

--- a/app/javascript/lib/imperial.js
+++ b/app/javascript/lib/imperial.js
@@ -1,4 +1,3 @@
-import { Logtail } from '@logtail/browser';
 import { translateProvinceModel } from './Entities/Board/Province';
 import Imperial2030Game from './Entities/Imperial2030Game';
 import ImperialAsiaGame from './Entities/ImperialAsiaGame';
@@ -38,7 +37,6 @@ export default class Imperial {
   }
 
   constructor(board) {
-    this.logtail = new Logtail('3bdHcA8P3mcww2ojgC5G8YiT');
     this.invalidAction = false;
     this.board = board || standardGameBoard;
     // This is the canonical log from which game state is derived.

--- a/app/javascript/src/router/index.js
+++ b/app/javascript/src/router/index.js
@@ -1,9 +1,11 @@
-import { createRouter, createWebHistory } from 'vue-router';
+import { Logtail } from '@logtail/browser';
 import ActionCable from 'actioncable';
+import { createRouter, createWebHistory } from 'vue-router';
 import Home from '../views/Home.vue';
 
 class APIClient {
   constructor() {
+    this.logtail = new Logtail('3bdHcA8P3mcww2ojgC5G8YiT');
     this.ws = this.initws();
     this.handlers = {};
     this.messageQueue = [];
@@ -20,7 +22,7 @@ class APIClient {
         if (this.handlers[envelope.kind]) {
           this.handlers[envelope.kind](envelope.data);
         } else {
-          console.error(envelope);
+          this.logtail.error('unhandled websocket envelope kind in GameChannel', envelope);
           throw new Error(`unhandled kind: ${envelope.kind}`);
         }
       },
@@ -30,7 +32,7 @@ class APIClient {
         if (this.handlers[envelope.kind]) {
           this.handlers[envelope.kind](envelope.data);
         } else {
-          console.error(envelope);
+          this.logtail.error('unhandled websocket envelope kind in AppearanceChannel', envelope);
           throw new Error(`unhandled kind: ${envelope.kind}`);
         }
       },
@@ -39,12 +41,7 @@ class APIClient {
   }
 
   onclose() {
-    console.info('replacing closed websocket');
     this.ws = this.initws();
-  }
-
-  onerror(err) {
-    console.error('websocket error', err);
   }
 
   send(data, channel) {
@@ -102,11 +99,11 @@ class APIClient {
     );
   }
 
-  openGame(id, base_game, variant, create_discord_channel, is_game_public) {
+  openGame(id, baseGame, variant, createDiscordChannel, isGamePublic) {
     return fetch('/games', {
       method: 'POST',
       body: JSON.stringify({
-        id, base_game, variant, create_discord_channel, is_game_public,
+        id, base_game: baseGame, variant, create_discord_channel: createDiscordChannel, is_game_public: isGamePublic,
       }),
       headers: { 'Content-Type': 'application/json' },
     })
@@ -285,6 +282,11 @@ const routes = [
     path: '/cloned_games',
     name: 'ClonedGames',
     component: () => import('../views/ClonedGames.vue'),
+  },
+  {
+    path: '/import_game',
+    name: 'ImportGame',
+    component: () => import('../views/ImportGame.vue'),
   },
   {
     path: '/forgot_password',

--- a/app/javascript/src/views/ImportGame.vue
+++ b/app/javascript/src/views/ImportGame.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <form
+      class="flex flex-col mx-auto rounded bg-green-200 sm:max-w-4xl mt-10 sm:p-20"
+      @submit="importGame"
+    >
+      <textarea
+        v-model="gameLog"
+        class="rounded p-5 border border-green-800 my-2 sm:w-full self-center"
+      />
+      <input
+        type="submit"
+        value="Import game"
+        class="rounded p-5 bg-green-800 text-white cursor-pointer my-2 text-2xl sm:w-1/2 self-center"
+      >
+    </form>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ImportGame',
+  props: ['profile'],
+  data() {
+    return {
+      gameLog: '',
+    };
+  },
+  created() {
+    document.title = 'Import - Imperial';
+  },
+  methods: {
+    importGame(e) {
+      fetch('/imports', {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': this.$cookies.get('CSRF-TOKEN'),
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ log: this.gameLog }),
+      })
+        .then((response) => response.json())
+        .then((game) => {
+          this.$router.push(`/game/${game.id}`);
+        });
+      e.preventDefault();
+    },
+  },
+};
+</script>

--- a/app/javascript/src/views/ImportGame.vue
+++ b/app/javascript/src/views/ImportGame.vue
@@ -20,7 +20,9 @@
 <script>
 export default {
   name: 'ImportGame',
-  props: ['profile'],
+  props: {
+    profile: { type: Object, default: () => {} },
+  },
   data() {
     return {
       gameLog: '',
@@ -37,7 +39,7 @@ export default {
           'X-CSRF-Token': this.$cookies.get('CSRF-TOKEN'),
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ log: this.gameLog }),
+        body: JSON.stringify({ log: this.gameLog, hostId: this.profile.id }),
       })
         .then((response) => response.json())
         .then((game) => {

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -40,6 +40,12 @@ class Game < ActiveRecord::Base
     }
   end
 
+  def log
+    actions.order(:created_at).map do |action|
+      JSON.parse(action.data)
+    end
+  end
+
   def abandoned?
     if actions.length > 0 && !force_ended_at
       return actions.order(:created_at).last.created_at < 7.days.ago

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -22,6 +22,7 @@ class Game < ActiveRecord::Base
     initialize_payload = log[0]["payload"]
     raise ArgumentError unless log[0]["type"] == "initialize"
 
+    imported_games_count = Game.where(is_imported: true).count
     host = User.find(host_id)
     game = Game.new(base_game: initialize_payload["baseGame"], variant: initialize_payload["variant"], host: host)
     initialize_payload["players"].each do |player|
@@ -29,9 +30,13 @@ class Game < ActiveRecord::Base
       game.players << Player.new(user: user)
     end
     log.each do |action|
+      if action["type"] == "initialize"
+        action["payload"]["soloMode"] = true
+      end
       game.actions << Action.new(data: action.to_json)
     end
     game.is_imported = true
+    game.name = "Imported game: #{imported_games_count + 1}"
     game.save!
     game
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
   resources :clone_games, only: [:create]
   resources :exports, only: [:show]
+  resources :imports, only: [:create]
 
   namespace :api do
     resources :users, only: [:show, :create, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   post "/games", to: "games#create"
 
   resources :clone_games, only: [:create]
+  resources :exports, only: [:show]
 
   namespace :api do
     resources :users, only: [:show, :create, :update]

--- a/db/migrate/20230326173107_add_is_imported_to_games.rb
+++ b/db/migrate/20230326173107_add_is_imported_to_games.rb
@@ -1,0 +1,5 @@
+class AddIsImportedToGames < ActiveRecord::Migration[7.0]
+  def change
+    add_column :games, :is_imported, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_01_163154) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_26_173107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_01_163154) do
     t.uuid "cloned_from_game_id"
     t.boolean "is_public", default: true
     t.string "discord_channel_id"
+    t.boolean "is_imported"
     t.index ["cloned_from_game_id"], name: "index_games_on_cloned_from_game_id"
     t.index ["current_player_id"], name: "index_games_on_current_player_id"
     t.index ["host_id"], name: "index_games_on_host_id"

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe Game, "#to_json" do
   end
 end
 
+RSpec.describe Game, "#log" do
+  context "game has two actions" do
+    let(:game) { create(:game) }
+    action1_string = "{\"type\":\"rondel\",\"payload\":{\"nation\":{\"value\":\"CN\",\"label\":\"Nation2030\"},\"cost\":0,\"slot\":\"production1\"}}"
+    action2_string = "{\"type\":\"maneuver\",\"payload\":{\"origin\":\"northafrica\",\"destination\":\"nigeria\"}}"
+    let!(:action1) { create(:action, data: action1_string, game: game, created_at: 2.days.ago) }
+    let!(:action2) { create(:action, data: action2_string, game: game, created_at: 1.day.ago) }
+
+    it "converts the actions to a game log as json" do
+      expect(game.log).to eq([
+        JSON.parse(action1_string),
+        JSON.parse(action2_string)
+      ])
+    end
+  end
+end
+
 RSpec.describe Game, "#abandoned?" do
   context "last action was more than 7 days ago" do
     let(:game) { create(:game, created_at: 8.days.ago) }

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -46,6 +46,73 @@ RSpec.describe Game, "#log" do
   end
 end
 
+RSpec.describe Game, "#import" do
+  context "valid input" do
+    let!(:host) { create(:user) }
+
+    action1 = {
+      "type" => "initialize",
+      "payload" => {
+        "players" => [
+          {"id" => "Henry", "nation" => {"value" => "RU", "label" => "Nation2030"}},
+          {"id" => "Otto", "nation" => {"value" => "CN", "label" => "Nation2030"}},
+          {"id" => "Raguel the Seal", "nation" => {"value" => "IN", "label" => "Nation2030"}},
+          {"id" => "Louis", "nation" => {"value" => "BR", "label" => "Nation2030"}},
+          {"id" => "Conrad", "nation" => {"value" => "US", "label" => "Nation2030"}},
+          {"id" => "Charles", "nation" => {"value" => "EU", "label" => "Nation2030"}}
+        ],
+        "soloMode" => true,
+        "variant" => "standard",
+        "baseGame" => "imperial2030"
+      }
+    }
+    action2 = {"type" => "rondel", "payload" => {"nation" => {"value" => "RU", "label" => "Nation2030"}, "cost" => 0, "slot" => "factory"}}
+    action3 = {"type" => "buildFactory", "payload" => {"province" => "novosibirsk"}}
+
+    log = [action1, action2, action3]
+
+    it "creates a Game record" do
+      expect { Game.import(log, host.id) }.to change { Game.count }.by(1)
+    end
+
+    it "imports the right actions" do
+      game = Game.import(log, host.id)
+
+      expect(game.actions[0].data).to eq(action1.to_json)
+      expect(game.actions[1].data).to eq(action2.to_json)
+      expect(game.actions[2].data).to eq(action3.to_json)
+    end
+
+    it "inserts the right number of players" do
+      game = Game.import(log, host.id)
+      expected_names = ["Henry", "Otto", "Raguel the Seal", "Louis", "Conrad", "Charles"]
+
+      game.players.each_with_index do |player, index|
+        expect(player.user.name).to start_with expected_names[index]
+      end
+    end
+
+    it "indicates that it is imported" do
+      game = Game.import(log, host.id)
+
+      expect(game.is_imported).to be(true)
+    end
+  end
+
+  context "invalid input, missing initialize action" do
+    let!(:host) { create(:user) }
+
+    action1 = {"type" => "rondel", "payload" => {"nation" => {"value" => "RU", "label" => "Nation2030"}, "cost" => 0, "slot" => "factory"}}
+    action2 = {"type" => "buildFactory", "payload" => {"province" => "novosibirsk"}}
+
+    log = [action1, action2]
+
+    it "raises an error" do
+      expect { Game.import(log, host.id) }.to raise_error(ArgumentError)
+    end
+  end
+end
+
 RSpec.describe Game, "#abandoned?" do
   context "last action was more than 7 days ago" do
     let(:game) { create(:game, created_at: 8.days.ago) }


### PR DESCRIPTION
So far all this does is allow someone to download a game by hitting a certain endpoint (`/exports/[:game_id]`). Things left to do:

1. Build a FE for submitting a game log JSON (file upload? text paste?). Be sure that only certain people have access to this and that it is disabled on prod. Should only be needed on development environment.
2. Build a way to reconstruct a game from just a log (???) Do we need more than just the log? What will player names be? Does it matter?
3. ???
4. Profit! (but don't cuz we didn't design this board game in the first place)

UPDATE: Everything should be working but we just need to test it all!