### PR TITLE
Fix some noisy tests

### DIFF
--- a/app/javascript/lib/imperial.test.js
+++ b/app/javascript/lib/imperial.test.js
@@ -3,6 +3,8 @@ import Action from './action';
 import { Bond, Nation } from './constants';
 import GameBoard from './gameBoard';
 
+import Logger from '../src/Logger';
+
 import Imperial from './imperial';
 
 const cloneUnits = (units) => {
@@ -633,7 +635,6 @@ describe('imperial', () => {
           game.tick(
             Action.rondel({ slot: 'maneuver2', cost: 0, nation: Nation.AH }),
           );
-          game.tick(Action.endManeuver());
           game.tick(
             Action.rondel({ slot: 'taxation', cost: 0, nation: Nation.IT }),
           );
@@ -2222,7 +2223,7 @@ describe('imperial', () => {
                 // Set AH's rondel position to be something *before* investor
                 game.nations.get(Nation.AH).rondelPosition = startingPosition;
 
-                // The investor slot lies between 'maneuver1' and 'maneuver2'
+                // The investor slot lies between 'maneuver1' and 'production2'
                 game.tick(
                   Action.rondel({
                     slot: 'production2',
@@ -2270,7 +2271,7 @@ describe('imperial', () => {
                 // Set AH's rondel position to be something *before* investor
                 game.nations.get(Nation.AH).rondelPosition = startingPosition;
 
-                // The investor slot lies between 'maneuver1' and 'maneuver2'
+                // The investor slot lies between 'maneuver1' and 'production2'
                 game.tick(
                   Action.rondel({
                     slot: 'production2',
@@ -2278,7 +2279,6 @@ describe('imperial', () => {
                     cost: 0,
                   }),
                 );
-                game.tick(Action.skipForceInvestor({ player: 'player2' }));
                 // InvestorCardHolder buys a bond first
                 game.tick(
                   Action.bondPurchase({
@@ -3878,7 +3878,7 @@ describe('imperial', () => {
           game.tick(
             Action.rondel({ slot: 'maneuver1', nation: Nation.AH, cost: 0 }),
           );
-          game.tick(Action.maneuver({ origin: 'f', destination: 'e' }));
+          game.tick(Action.maneuver({ origin: 'f', destination: 'c' }));
 
           expect(game.provinces.get('f').flag).toEqual(Nation.AH);
         });
@@ -3914,11 +3914,18 @@ describe('imperial', () => {
           game.units.get(Nation.IT).get('a').armies += 1;
 
           game.tick(
+            Action.rondel({
+              nation: Nation.AH,
+              cost: 0,
+              slot: 'maneuver1',
+            }),
+          );
+          game.tick(
             Action.fight({
               province: 'a',
               incumbent: Nation.AH,
               challenger: Nation.IT,
-              targetType: null,
+              targetType: 'army',
             }),
           );
 
@@ -4624,7 +4631,8 @@ describe('imperial', () => {
           edges: [['a', 'c']],
         });
 
-        const game = new Imperial(board);
+        const logger = new Logger('silent');
+        const game = new Imperial(board, logger);
         initialize(game);
         return game;
       };

--- a/app/javascript/lib/imperial2030.test.js
+++ b/app/javascript/lib/imperial2030.test.js
@@ -1,8 +1,8 @@
 import Action from './action';
 
+import { Nation2030 } from './constants';
 import GameBoard from './gameBoard';
 import Imperial from './imperial';
-import { Nation2030 } from './constants';
 
 const initialize = (game) => {
   game.tick(
@@ -285,7 +285,6 @@ describe('imperial2030', () => {
         game.tick(
           Action.rondel({ slot: 'maneuver1', cost: 0, nation: Nation2030.RU }),
         );
-        game.tick(Action.endManeuver());
 
         expect(game.availableActions).toEqual(expected);
       });
@@ -314,7 +313,6 @@ describe('imperial2030', () => {
         game.tick(
           Action.rondel({ slot: 'maneuver1', cost: 0, nation: Nation2030.RU }),
         );
-        game.tick(Action.endManeuver());
 
         expect(game.availableActions).toEqual(expected);
       });

--- a/app/javascript/lib/imperialWithoutInvestorCard.test.js
+++ b/app/javascript/lib/imperialWithoutInvestorCard.test.js
@@ -253,6 +253,7 @@ describe('round of investment', () => {
     game.tick(Action.bondPurchase({
       player: 'player2', cost: 9, nation: Nation.IT, tradeInValue: 0,
     }));
+    game.tick(Action.skipBondPurchase({ player: 'player3', nation: Nation.IT }));
     game.tick(Action.rondel({ nation: Nation.FR, cost: 0, slot: 'investor' }));
     game.tick(Action.bondPurchase({
       player: 'player3', cost: 9, nation: Nation.FR, tradeInValue: 0,

--- a/app/javascript/src/Logger.js
+++ b/app/javascript/src/Logger.js
@@ -22,6 +22,7 @@ export default class Logger {
         break;
 
       case 'replay':
+      case 'silent':
         // no-op
         break;
 


### PR DESCRIPTION
This PR does a couple things that should help:
- Introduce a `'silent'` Logger so that when we test purposely-invalid moves it doesn't clutter up logs.
- Fix some tests that were silently failing. (For example, some `endManeuver`s are removed because when they were first put in we didn't automatically end a player's maneuver turn when they ran out of valid maneuvers. Once that rule came online, these tests were not updated because they were silently dropping those invalid actions)