### PR TITLE
ImperialGameCoordinator no longer casted into proxy

### DIFF
--- a/app/javascript/src/views/Game.vue
+++ b/app/javascript/src/views/Game.vue
@@ -396,10 +396,10 @@
 
 <script>
 import { Howl } from 'howler';
+import { markRaw } from 'vue';
 import Action from '../../Domain/action';
 import Imperial from '../../Domain/ImperialGameCoordinator';
 import { apiClient } from '../router/index';
-import { markRaw } from 'vue';
 
 import Logger from '../Logger';
 

--- a/app/javascript/src/views/Game.vue
+++ b/app/javascript/src/views/Game.vue
@@ -399,6 +399,7 @@ import { Howl } from 'howler';
 import Action from '../../Domain/action';
 import Imperial from '../../Domain/ImperialGameCoordinator';
 import { apiClient } from '../router/index';
+import { markRaw } from 'vue';
 
 import Logger from '../Logger';
 
@@ -611,13 +612,11 @@ export default {
         this.board = imperialAsiaBoard;
       }
 
-      const game = new Imperial(this.board, new Logger(this.env, this.gameData.id));
+      this.game = markRaw(new Imperial(this.board, new Logger(this.env, this.gameData.id)));
       if (baseGame) {
-        game.baseGame = baseGame;
+        this.game.baseGame = baseGame;
       }
-      game.tickFromLog(gameLog);
-      // assigning to this.game makes the object a proxy and unable to access private fields
-      this.game = game;
+      this.game.tickFromLog(gameLog);
 
       if (Object.keys(this.game.players).length > 0) {
         this.gameStarted = true;
@@ -776,13 +775,11 @@ export default {
       const { log } = this.game;
       const { baseGame } = this.game;
 
-      const game = new Imperial(this.board, new Logger('replay', this.gameData.id));
+      this.game = markRaw(new Imperial(this.board, new Logger('replay', this.gameData.id)));
       if (baseGame) {
-        game.baseGame = baseGame;
+        this.game.baseGame = baseGame;
       }
-      game.tickFromLog(log);
-      // assigning to this.game makes the object a proxy and unable to access private fields, doing it last
-      this.game = game;
+      this.game.tickFromLog(log);
     },
     backToRoundStart() {
       const startingNation = this.game.baseGame === 'imperial' ? Nation.AH : Nation2030.RU;
@@ -798,13 +795,11 @@ export default {
       const { log } = this.game;
       const { baseGame } = this.game;
 
-      const game = new Imperial(this.board, new Logger('replay', this.gameData.id));
+      this.game = markRaw(new Imperial(this.board, new Logger('replay', this.gameData.id)));
       if (baseGame) {
-        game.baseGame = baseGame;
+        this.game.baseGame = baseGame;
       }
-      game.tickFromLog(log);
-      // assigning to this.game makes the object a proxy and unable to access private fields, doing it last
-      this.game = game;
+      this.game.tickFromLog(log);
     },
     backToGameStart() {
       while (this.game.log[this.game.log.length - 1].type !== 'initialize') {
@@ -820,13 +815,11 @@ export default {
       }
       const { baseGame } = this.game;
 
-      const game = new Imperial(this.board, new Logger('replay', this.gameData.id));
+      this.game = markRaw(new Imperial(this.board, new Logger('replay', this.gameData.id)));
       if (baseGame) {
-        game.baseGame = baseGame;
+        this.game.baseGame = baseGame;
       }
-      game.tickFromLog(newLog);
-      // assigning to this.game makes the object a proxy and unable to access private fields, doing it last
-      this.game = game;
+      this.game.tickFromLog(newLog);
     },
     forwardToCurrentAction() {
       while (this.poppedTurns.length > 0) {


### PR DESCRIPTION
## Comments:
- Having the game being casted into proxies was still causing issues eventually down the line w.r.t. private fields, forcing it to always stay as obj